### PR TITLE
Make the README more concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,41 @@
 
 ### Q. What is this quest?
 
-It is a fun way to assess your cloud skills. It is also a good representative sample of the work we do at Rearc. Quest is a webapp made with node.js and golang.
+It is a fun way to assess your cloud skills. It is also a good representative sample of the work we do at Rearc.
 
-### Q. Do I need to be an expert in node.js and golang?
-
-No. The starting point of the quest app is `npm install && npm start`. That is all the node.js you need to know. And you wont even see golang.
-
-### Q. So what skills should I have?
-
-AWS. General cloud concepts, especially networking. Docker (containerization). IaC (Infrastructure as code). Linux/Unix. Git. TLS certs is a plus.
+You will be given an application written in node.js and Golang, but no knowledge of these two languages is required. Then you will show that you understand how to deploy this application to the cloud.
 
 ### Q. What do I have to do?
 
 You may do all or some of the following tasks. Please read over the complete list before starting.
 
-1. If you know how to use git, start a git repository (local-only is acceptable) and commit all of your work to it.
-2. Deploy the app in AWS and navigate to the index page. Use Linux 64-bit as your OS (Amazon Linux preferred).
-3. Deploy the app in a Docker container. Use `node:10` as the base image.
-4. Inject an environment variable (`SECRET_WORD`) in the Docker container. The value of `SECRET_WORD` should be the secret word discovered on the index page of the application.
+**Note**: If you know how to use git, it is recommended to start a git repository (even if you don't host it anywhere), and commit your progress as you would normally on a work project.
+
+To run the app, simply execute `npm run` (after installing dependencies).
+
+1. Run the app and navigate to the index page. This is just to ensure you can get the app running as expected.
+2. Deploy the app in a container. For Docker, use `node:10` as the base image.
+3. Inject an environment variable (`SECRET_WORD`) in the container. The value of `SECRET_WORD` is found on the index page.
+4. Deploy the application to the cloud. Use Linux 64-bit as your OS (for AWS, Amazon Linux is preferred).
 5. Deploy a load balancer in front of the app.
-6. Use Infrastructure as Code (IaC) to "codify" your deployment. Terraform is ideal, but use whatever you know, e.g. CloudFormation, CDK, Deployment Manager, etc.
-7. Add TLS (https). You may use locally-generated certs.
+6. Add TLS (https). You may use self-signed certs.
+7. Use Infrastructure as Code (IaC) to "codify" your deployment. Terraform is ideal, but use whatever you know, e.g. CloudFormation, CDK, Deployment Manager, etc.
 
 ### Q. How do I know I have solved these stages?
 
-Each stage can be tested as follows (where `<ip_or_host>` is the location where the app is deployed):
+Each "check" can be tested by visiting the following endpoints:
 
-1. Index page (contains the secret word) - `http(s)://<ip_or_host>[:port]/`
-2. Docker check - `http(s)://<ip_or_host>[:port]/docker`
-3. Secret Word check - `http(s)://<ip_or_host>[:port]/secret_word`
-4. Load Balancer check  - `http(s)://<ip_or_host>[:port]/loadbalanced`
-5. TLS check - `http(s)://<ip_or_host>[:port]/tls`
+| Check Name | Endpoint Path |
+| ---------- | ------------- |
+| Index | `/` |
+| Container | `/docker` |
+| Secret Word | `/secret_word` |
+| Load Balancer | `/loadbalanced` |
+| TLS | `/tls` |
 
 ### Q. Do I have to do all these?
 
-You may do whichever, and however many, of the tasks above as you'd like. We suspect that once you start, you won't be able to stop. It's addictive.
+No. If you feel that time may be an issue, prioritize the above list of tasks and go as far as you can before you need to stop. You don't fail just because you didn't finish every single item in the list.
 
 ### Q. What do I have to submit?
 
@@ -50,7 +50,7 @@ You may do whichever, and however many, of the tasks above as you'd like. We sus
 Your work assets should include:
 
 - IaC files, if you completed that task.
-- One or more Dockerfiles, if you completed that task.
+- One or more container specs (e.g. Dockerfile), if you completed that task.
 - A sensible README or other file(s) that contain instructions, notes, or other written documentation to help us review and assess your submission.
 
 ### Q. How long do I need to host my submission on AWS?
@@ -59,17 +59,9 @@ You don't have to at all if you don't want to. You can run it in AWS, grab a scr
 
 If you _want_ to host it longer for us to view it, we recommend taking a screenshot anyway and sending that along with the link. Then you can tear down the quest whenever you want and we'll still have the screenshot. We recommend waiting no longer than one week after sending us the link before tearing it down.
 
-### Q. What if I successfully complete all the challenges?
-
-We have many more for you to solve as a member of the Rearc team!
-
 ### Q. What if I find a bug?
 
 Awesome! Tell us you found a bug in your submission to us, ideally in an email, and we'll talk more!
-
-### Q. What if I fail?
-
-There is no fail. Complete whatever you can and then submit your work. Doing _everything_ in the quest is not a guarantee that you will "pass" the quest, just like not doing something is not a guarantee you will "fail" the quest.
 
 ### Q. Can I share this quest with others?
 


### PR DESCRIPTION
The instructions could be clearer, in my opinion, so I'm hoping that making the README more concise does precisely that.

Additionally, I feel as though some candidates don't read through the entire document based on some of their questions and feedback, and that's really not their fault as the README is exceptionally long for a "simple" take home challenge. Shortening the README should hopefully ensure that candidates are reading through the entirety of the document before they get started.

Plus, who wants to read that much text for a take home challenge when candidates are likely still working a full-time job and possibly interviewing with other companies concurrently? Let's keep things short and simple for our candidates.